### PR TITLE
Add title prop to calendar event titles

### DIFF
--- a/calendar/CalendarEventTabs.html
+++ b/calendar/CalendarEventTabs.html
@@ -552,7 +552,7 @@
                     {{subject}}
                   </a>
                   {{else}}
-                  {{subject}}
+                    <span title="{{subject}}">{{subject}}</span>
                   {{/if}}
                 </div>
                 <div class="dateTime">


### PR DESCRIPTION
When an event title is shortened with an ellipsis (too long for the box), you have to click the item to read the whole event title.
Added the title property on the event title, so that when you hover the title, the whole text will show (and not just "Åpne i Outlook"). 

Example:
![image](https://user-images.githubusercontent.com/13292913/95764966-749b1f80-0cb1-11eb-9b10-97f169f536f5.png)
